### PR TITLE
Integrated links in best practice text using [linktext] brackets

### DIFF
--- a/components/phaseStepView.tsx
+++ b/components/phaseStepView.tsx
@@ -38,6 +38,25 @@ export const PhaseStepView: React.FC<{step: PhaseStep}> = ({step}) => {
         }
     }
 
+    /*
+        Takes a description and a list of URL's.
+        The description needs to have square brackets where the links should be.
+        The first instance of a text wrapped in [] will transform to a link text with the first url in the list.
+        This continues for each occurrence where the occurrence number matches the index of the url in the list.
+    */
+    function formatBestPracticeDescription(description, urlList){
+        let descArr = description.split(/\[(.*?)\]/);
+        let returnHTML = [];
+        for(let i = 0; i < descArr.length; i++){
+            if(i % 2 != 0){
+                returnHTML.push(<a target="_blank" href="{urlList[i]}">{descArr[i]}</a>);
+            }else{
+                returnHTML.push(<span>{descArr[i]}</span>);
+            }
+        }
+        return returnHTML;
+    }
+
     function getFormInput() {
         switch (step.answerType) {
             case "BOOLEAN":
@@ -62,7 +81,9 @@ export const PhaseStepView: React.FC<{step: PhaseStep}> = ({step}) => {
             {step.bestPractice &&
                 <div className={"bestPracticeContainer"}>
                     <h3>Best practice resources</h3>
-                    <div className={"bestPracticeDescription"}>{step.bestPractice.description}</div>
+                    <div className={"bestPracticeDescription"}>{formatBestPracticeDescription(step.bestPractice.description, step.bestPractice.urls)}</div>
+                    {/*<div className={"bestPracticeDescription"}>{step.bestPractice.description}</div>*/}
+                    {/*Format best practice*/}
                     {step.bestPractice.urls.map((url, id) => <div className={"bestPracticeLink"} key={id}><a href={url} target={"_blank"}>{url}</a></div>)}
                 </div>
             }


### PR DESCRIPTION
Can now use brackets [] to mark parts of the description text that should be a link. The order must be the same as the order or urls related to the description.
The url list below the description is not removed yet